### PR TITLE
BankSearchLayout: don't truncate search string

### DIFF
--- a/runelite-client/src/main/scripts/BankSearchLayout.rs2asm
+++ b/runelite-client/src/main/scripts/BankSearchLayout.rs2asm
@@ -768,7 +768,7 @@ LABEL681:
    jump                   LABEL726
 LABEL685:
    get_varc_string        359                ; Skip truncating of varcstr 22 by not calling 280
-   invoke                 280; instead get the var directly and lowercase it
+   lowercase ; instead get the var directly and lowercase it
    sstore                 0
    sload                  0
    string_length         


### PR DESCRIPTION
This is a regression from 592ca5c112b0c8c68353dcef2f0df8ff0de6969a which
I mistakingly didn't fix last week